### PR TITLE
Make worker checks longer

### DIFF
--- a/app/src/main/java/com/openstablediffusion/MainActivity.kt
+++ b/app/src/main/java/com/openstablediffusion/MainActivity.kt
@@ -163,7 +163,7 @@ class MainActivity : AppCompatActivity(), MainInterface, ViewTreeObserver.OnWind
                 runOnUiThread {
                     generation.displayWaitingTime(temp)
                 }
-                delay(500)
+                delay(5000)
             }
 
             // Get the image and parse it's data


### PR DESCRIPTION
Current models generate images at least 5 seconds, so knocking the network every half second might be an overload (of SD workers and mobile operator).

And thanks for program! 🙂